### PR TITLE
Add Travis CI build instructions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,16 @@
+sudo: required
+language: c
+before_install:
+ - echo "deb http://de.archive.ubuntu.com/ubuntu/ precise multiverse" | sudo tee -a /etc/apt/sources.list
+ - sudo apt-get update -qq
+install:
+ - sudo apt-get install -qq -y mlton libssl-dev
+ - wget http://impredicative.com/ur/urweb-20150819.tgz
+ - tar xzf urweb-20150819.tgz
+ - cd urweb-20150819
+ - ./configure --without-emacs
+ - make
+ - sudo make install
+script:
+ - cd $TRAVIS_BUILD_DIR
+ - make all

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 
-URWEB := urweb
+URWEB ?= urweb
 
 .PHONY: default check clean demos all
 


### PR DESCRIPTION
We pull down the tarball from impredicative.com.  Now that Ur/Web's in wily, we should start using the package (heck, we could do an OS X build, too), but this approach is sufficient for now.
